### PR TITLE
Fix Black-Scholes typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This contains:
   1. Analytical solution of Black-Scholes equation and sensitivity analysis of Option price to different parameters.
   2. Option Greeks: Delta, Gamma, Vega, Theta
       * Plots of how these Greeks for call options varies with Time-to-Maturity.
-  3. Numerical Solution to Balck-Scholes
+  3. Numerical Solution to Black-Scholes
       * Monte Carlo
       * Finite Difference
   4. Interactive app made using [Streamlit](https://www.streamlit.io/)

--- a/markdown_files/introduction.md
+++ b/markdown_files/introduction.md
@@ -9,7 +9,7 @@ This contains:
   1. Analytical solution of Black-Scholes equation and sensitivity analysis of Option price to different parameters.
   2. Option Greeks: Delta, Gamma, Vega, Theta
     * Plots of how these Greeks for call options varies with Time-to-Maturity.
-  3. Numerical Solution to Balck-Scholes
+  3. Numerical Solution to Black-Scholes
 	  * Monte Carlo
 	  * Finite Difference
   4. Volatility Surface


### PR DESCRIPTION
## Summary
- fix the bullet point referencing Black-Scholes in README
- fix the same typo in introduction.md

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68522f16af3c832fa61a9a09675103d0